### PR TITLE
Feature 43 mobile layouts need fixing

### DIFF
--- a/css/layout.css
+++ b/css/layout.css
@@ -1094,7 +1094,7 @@ table.advgb-table-frontend th {
   -webkit-transform: translateY(-50%);
           transform: translateY(-50%);
   margin: 0 auto;
-  padding: 0 4rem;
+  padding: 0 2rem;
   z-index: 10;
   width: 100%;
   max-width: 80em;
@@ -1105,9 +1105,12 @@ table.advgb-table-frontend th {
   .hero__content {
     padding: 0 4rem;
   }
+  .hero__content h1 {
+    font-size: clamp(2rem, 2vw + 4rem, 10rem) !important;
+  }
 }
 .hero__content h1 {
-  font-size: clamp(2rem, 2vw + 4rem, 10rem);
+  font-size: clamp(1vw, 10vw, 20vw);
   font-family: "questa-grande", sans-serif;
   font-style: italic;
 }
@@ -1290,13 +1293,13 @@ table.advgb-table-frontend th {
 .front-content .container {
   margin: 0 auto 4rem;
 }
-@media screen and (min-width: 40rem) {
+@media screen and (min-width: 50rem) {
   .front-content .container {
     display: -ms-grid;
     display: grid;
-    -ms-grid-columns: 70% 5% 25%;
-    grid-template-columns: 70% 25%;
-    gap: 5%;
+    -ms-grid-columns: 70% 2% 28%;
+    grid-template-columns: 70% 28%;
+    gap: 2%;
   }
 }
 

--- a/css/layout.css
+++ b/css/layout.css
@@ -726,6 +726,7 @@ table.advgb-table-frontend th {
 .site-header .site-branding .logo a {
   display: block;
   width: 11rem;
+  max-width: 70%;
   height: 5rem;
   padding-top: 5rem;
   overflow: hidden;
@@ -1110,7 +1111,7 @@ table.advgb-table-frontend th {
   }
 }
 .hero__content h1 {
-  font-size: clamp(1vw, 10vw, 20vw);
+  font-size: clamp(12vw, 12vw, 12vw);
   font-family: "questa-grande", sans-serif;
   font-style: italic;
 }
@@ -1172,6 +1173,7 @@ table.advgb-table-frontend th {
 .page-hero {
   max-width: 100vw;
   height: 15.6rem;
+  max-height: 55vw;
   margin: 2rem auto;
   background-color: transparent;
   background-image: url("../images/mikkeli-page-banner-default.jpg");

--- a/etusivu-tpl.php
+++ b/etusivu-tpl.php
@@ -133,7 +133,7 @@ get_header(); ?>
 
 	<section class="mikkeli-events">
 		<div class="container">
-			<h2><?php _e('Tapahtumakalenteri', 'mikkeli'); ?></h2>
+			<h2><?php _e('Tapahtuma&shy;kalenteri', 'mikkeli'); ?></h2>
 			<script type='text/javascript' src='https://www.mikkelinyt.fi/widget-loader/62835af416022e6c36e12d1b'></script>
 			<div id='EVENTZWIDGET-62835af416022e6c36e12d1b'></div>
 		</div>


### PR DESCRIPTION
Fixed: 
 - overlapping grid elements
 - titles, headers and logos that go over the side on mobile